### PR TITLE
Refine UI theme and accessibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,8 @@ body {
   font-family: var(--font-inter), sans-serif;
   transition: background 0.3s ease, color 0.3s ease;
 }
+
+a:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,10 @@ import { Pill } from "@/components/Pill";
 import { Section } from "@/components/Section";
 
 export default function Home() {
+  const navLinkClass =
+    "rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500";
   return (
-    <div className="min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-100 text-gray-700 antialiased dark:from-gray-950 dark:via-gray-900 dark:to-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-gray-50 text-gray-700 antialiased dark:bg-gray-950 dark:text-gray-100">
       {/* Header */}
       <header className="mx-auto max-w-5xl px-4 pt-10">
         <nav aria-label="Primary" className="mb-10 flex flex-wrap items-center justify-between gap-4">
@@ -13,49 +15,34 @@ export default function Home() {
           </a>
           <ul className="flex flex-wrap items-center gap-3 text-sm">
             <li>
-              <a
-                className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100"
-                href="#experience"
-              >
+              <a className={navLinkClass} href="#experience">
                 Experience
               </a>
             </li>
             <li>
-              <a
-                className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100"
-                href="#startups"
-              >
+              <a className={navLinkClass} href="#startups">
                 Startups
               </a>
             </li>
             <li>
-              <a
-                className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100"
-                href="#projects"
-              >
+              <a className={navLinkClass} href="#projects">
                 Projects
               </a>
             </li>
             <li>
-              <a
-                className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100"
-                href="#education"
-              >
+              <a className={navLinkClass} href="#education">
                 Education
               </a>
             </li>
             <li>
-              <a
-                className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100"
-                href="#contact"
-              >
+              <a className={navLinkClass} href="#contact">
                 Contact
               </a>
             </li>
           </ul>
         </nav>
 
-        <div className="mb-8 rounded-3xl bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 p-[2px]">
+        <div className="mb-8 rounded-3xl bg-gradient-to-r from-blue-600 to-teal-500 p-[2px]">
           <div className="rounded-3xl border border-gray-200 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-gray-800 dark:bg-gray-900/60">
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
             <div>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -7,7 +7,7 @@ interface SectionProps {
 export function Section({ id, title, children }: SectionProps) {
   return (
     <section id={id} className="scroll-mt-24">
-      <div className="sticky top-0 z-20 -mx-4 mb-6 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 px-4 py-2 text-white shadow dark:from-indigo-700 dark:via-purple-700 dark:to-pink-700">
+      <div className="sticky top-0 z-20 -mx-4 mb-6 bg-gradient-to-r from-blue-600 to-teal-500 px-4 py-2 text-white shadow dark:from-blue-700 dark:to-teal-600">
         <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
       </div>
       {children}


### PR DESCRIPTION
## Summary
- Refresh section and hero gradients with blue-to-teal scheme for cleaner look
- Simplify layout background and reuse navigation link styling with focus rings
- Add global focus-visible outlines for keyboard navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file)*

------
https://chatgpt.com/codex/tasks/task_e_689caeb208108333994499f7233800a7