### PR TITLE
Add default noopener rel for ButtonLink

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,13 +60,13 @@ export default function Home() {
               <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-700 dark:text-gray-200">{resume.summary}</p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <ButtonLink href={resume.contacts.website} target="_blank" rel="noreferrer">
+              <ButtonLink href={resume.contacts.website} target="_blank">
                 Website
               </ButtonLink>
-              <ButtonLink href={resume.contacts.linkedin} target="_blank" rel="noreferrer">
+              <ButtonLink href={resume.contacts.linkedin} target="_blank">
                 LinkedIn
               </ButtonLink>
-              <ButtonLink href={resume.contacts.github} target="_blank" rel="noreferrer">
+              <ButtonLink href={resume.contacts.github} target="_blank">
                 GitHub
               </ButtonLink>
               <ButtonLink href={`mailto:${resume.contacts.email}`} variant="primary">
@@ -129,7 +129,7 @@ export default function Home() {
                 />
                 <h3 className="text-lg font-semibold">{s.name}</h3>
                 <p className="mt-2 text-sm leading-6 text-gray-700 dark:text-gray-200">{s.blurb}</p>
-                <ButtonLink className="mt-4" href={s.link} target="_blank" rel="noreferrer">
+                <ButtonLink className="mt-4" href={s.link} target="_blank">
                   Visit Site
                 </ButtonLink>
               </article>
@@ -154,7 +154,7 @@ export default function Home() {
                     ))}
                   </div>
                 </div>
-                <ButtonLink className="mt-4" href={p.link} target="_blank" rel="noreferrer">
+                <ButtonLink className="mt-4" href={p.link} target="_blank">
                   View on GitHub
                 </ButtonLink>
               </article>
@@ -186,14 +186,14 @@ export default function Home() {
               <ButtonLink className="px-4 py-3" href={`mailto:${resume.contacts.email}`}>
                 {resume.contacts.email}
               </ButtonLink>
-              <ButtonLink className="px-4 py-3" href={resume.contacts.website} target="_blank" rel="noreferrer">
+              <ButtonLink className="px-4 py-3" href={resume.contacts.website} target="_blank">
                 {resume.contacts.website}
               </ButtonLink>
               <div className="flex flex-wrap gap-2">
-                <ButtonLink className="px-4 py-3" href={resume.contacts.linkedin} target="_blank" rel="noreferrer">
+                <ButtonLink className="px-4 py-3" href={resume.contacts.linkedin} target="_blank">
                   LinkedIn
                 </ButtonLink>
-                <ButtonLink className="px-4 py-3" href={resume.contacts.github} target="_blank" rel="noreferrer">
+                <ButtonLink className="px-4 py-3" href={resume.contacts.github} target="_blank">
                   GitHub
                 </ButtonLink>
               </div>

--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -22,8 +22,14 @@ export function ButtonLink({
     variant === "primary"
       ? "bg-black text-white hover:opacity-90 dark:bg-white dark:text-black"
       : "border border-gray-200 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800";
+  const computedRel = rel ?? (target === "_blank" ? "noopener noreferrer" : undefined);
   return (
-    <a href={href} target={target} rel={rel} className={`${base} ${styles} ${className ?? ""}`}>
+    <a
+      href={href}
+      target={target}
+      rel={computedRel}
+      className={`${base} ${styles} ${className ?? ""}`}
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
## Summary
- add automatic `rel="noopener noreferrer"` when `ButtonLink` opens in a new tab
- remove redundant `rel` props from home page `ButtonLink` uses

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a004f832248333acb8ff596a259d5c