### PR TITLE
feat: add theme toggle

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { Pill } from "@/components/Pill";
 import { Section } from "@/components/Section";
 import { Card } from "@/components/Card";
 import { ButtonLink } from "@/components/ButtonLink";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function Home() {
   const navLinkClass =
@@ -44,6 +45,9 @@ export default function Home() {
                 <a className={navLinkClass} href="#contact">
                   Contact
                 </a>
+              </li>
+              <li>
+                <ThemeToggle />
               </li>
             </ul>
           </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored ? (stored as 'light' | 'dark') : prefersDark ? 'dark' : 'light';
+    setTheme(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
+    localStorage.setItem('theme', initial);
+    setMounted(true);
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    document.documentElement.classList.toggle('dark', next === 'dark');
+    localStorage.setItem('theme', next);
+  };
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Toggle theme"
+      className="rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+    >
+      {theme === 'dark' ? 'Light' : 'Dark'}
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ThemeToggle component to switch between dark and light modes and store preference in localStorage
- surface theme switcher in header navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a004fd799c8333ad5efb3fe84bda68