### PR TITLE
feat: add social metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,29 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://ema93sh.github.io"),
   title: "Magesh Kumar Murali",
   description: "Senior Software Engineer",
+  openGraph: {
+    title: "Magesh Kumar Murali",
+    description: "Senior Software Engineer",
+    url: "https://ema93sh.github.io",
+    images: [
+      {
+        url: "https://ema93sh.github.io/globe.svg",
+        width: 1200,
+        height: 630,
+        alt: "Magesh Kumar Murali",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Magesh Kumar Murali",
+    description: "Senior Software Engineer",
+    images: ["https://ema93sh.github.io/globe.svg"],
+    site: "https://ema93sh.github.io",
+  },
 };
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata in layout
- define metadata base URL for absolute links

## Testing
- `npm run lint`
- `NEXT_DISABLE_FONT_DOWNLOADS=1 npm run build` (fails: Failed to fetch `Inter` from Google Fonts)
- `curl -s http://localhost:3000 | sed 's/></>\n</g' | grep -i 'og:'`
- `curl -s http://localhost:3000 | sed 's/></>\n</g' | grep -i 'twitter'`


------
https://chatgpt.com/codex/tasks/task_e_68a0050c61808333a823514bb173f30c