### PR TITLE
fix: build without remote fonts

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,5 @@
-import tailwindcss from '@tailwindcss/postcss';
-
 const config = {
-  plugins: [tailwindcss],
+  plugins: ['@tailwindcss/postcss'],
 };
 
 export default config;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -28,8 +27,6 @@ export const metadata: Metadata = {
   },
 };
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -37,7 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.className} antialiased bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100`}>
+      <body className="antialiased font-sans bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100">
         <a
           href="#content"
           className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:shadow dark:focus:bg-gray-900"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary
- remove Google font dependency from layout
- update PostCSS plugin config for Next.js 15
- exclude vitest config from TypeScript build

## Testing
- `npm run build`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f8b914c8333bab0221b5a6f0997